### PR TITLE
enable dropguard so that config import doesn't fail when hitting conf…

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   ctools_views: 0
   datetime: 0
   dblog: 0
+  dropguard: 0
   dropzonejs: 0
   dropzonejs_eb_widget: 0
   dynamic_page_cache: 0


### PR DESCRIPTION
…ig_ignore settings for a non-enabled module