### PR TITLE
#50241: Granted 'editor' role, 'administer menu' permission.

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -18,6 +18,7 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'access video_browser entity browser pages'
+  - 'administer menu'
   - 'administer meta tags'
   - 'administer node weight'
   - 'administer nodes'


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/50241

Granted `administer menu` permission to `editor` role, needed by client's editor user (Grace), to change node `menu link title` by herself.