### PR TITLE
#50486: Synchronized configuration files exported from 'active' prod.

### DIFF
--- a/config/sync/facets.facet.content_type.yml
+++ b/config/sync/facets.facet.content_type.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.content_type_solr.yml
+++ b/config/sync/facets.facet.content_type_solr.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.disease_type.yml
+++ b/config/sync/facets.facet.disease_type.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.disease_type_or_population_group.yml
+++ b/config/sync/facets.facet.disease_type_or_population_group.yml
@@ -53,3 +53,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.geographical_area.yml
+++ b/config/sync/facets.facet.geographical_area.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.impact_of_work.yml
+++ b/config/sync/facets.facet.impact_of_work.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.impact_of_work_solr.yml
+++ b/config/sync/facets.facet.impact_of_work_solr.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.sources_of_data.yml
+++ b/config/sync/facets.facet.sources_of_data.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.sources_of_data_solr.yml
+++ b/config/sync/facets.facet.sources_of_data_solr.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/facets.facet.type_of_user.yml
+++ b/config/sync/facets.facet.type_of_user.yml
@@ -59,3 +59,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/config/sync/search_api.index.main_solr.yml
+++ b/config/sync/search_api.index.main_solr.yml
@@ -422,13 +422,23 @@ datasource_settings:
       default: true
       selected: {  }
 processor_settings:
-  rendered_item: {  }
-  entity_status: {  }
   add_url: {  }
+  aggregated_field: {  }
   content_access:
     weights:
       preprocess_query: -30
-  language_with_fallback: {  }
+  entity_status: {  }
+  highlight:
+    highlight: always
+    highlight_partial: true
+    excerpt: true
+    excerpt_length: 256
+    exclude_fields:
+      - title
+    prefix: '<strong>'
+    suffix: '</strong>'
+    weights:
+      postprocess_query: 0
   html_filter:
     all_fields: true
     fields:
@@ -471,18 +481,8 @@ processor_settings:
     weights:
       preprocess_index: -15
       preprocess_query: -15
-  aggregated_field: {  }
-  highlight:
-    highlight: always
-    highlight_partial: true
-    excerpt: true
-    excerpt_length: 256
-    exclude_fields:
-      - title
-    prefix: '<strong>'
-    suffix: '</strong>'
-    weights:
-      postprocess_query: 0
+  language_with_fallback: {  }
+  rendered_item: {  }
   solr_date_range: {  }
 tracker_settings:
   default:


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/50486

_(cherry-picked from #341 / approved and reviewed from Dan)_
Updated files in the `config/sync` folder with the ones downloaded from an export of the configurations on the live site.

**Notes:**

- Minor changes to all facets files.
- Local search configuration have all changed because they're all enabled and configured:
search_api.index.content.yml, search_api.index.main_solr.yml, search_api.server.local_db.yml
- The view `site_search` has changed: views.view.site_search.yml