### PR TITLE
#49742: Changed block layout for 'upd_admin' theme.

### DIFF
--- a/config/sync/block.block.mainpagecontent.yml
+++ b/config/sync/block.block.mainpagecontent.yml
@@ -1,4 +1,4 @@
-uuid: c3b15173-4065-4d32-b6f8-5d85f5788a68
+uuid: af93ed93-c29e-4492-b3e7-c42edace36b5
 langcode: en
 status: true
 dependencies:
@@ -6,15 +6,16 @@ dependencies:
     - system
   theme:
     - upd_admin
-id: breadcrumbs
+id: mainpagecontent
 theme: upd_admin
-region: breadcrumb
-weight: -2
+region: content
+weight: -1
 provider: null
-plugin: system_breadcrumb_block
+plugin: system_main_block
 settings:
-  id: system_breadcrumb_block
-  label: Breadcrumbs
+  id: system_main_block
+  label: 'Main page content'
   provider: system
   label_display: '0'
 visibility: {  }
+

--- a/config/sync/block.block.pagetitle.yml
+++ b/config/sync/block.block.pagetitle.yml
@@ -1,0 +1,19 @@
+uuid: 4920e6ba-dcb7-459c-9266-2aa3adcfcdfc
+langcode: en
+status: true
+dependencies:
+  theme:
+    - upd_admin
+id: pagetitle
+theme: upd_admin
+region: header
+weight: -3
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  provider: core
+  label_display: '0'
+visibility: {  }
+

--- a/config/sync/block.block.tabs.yml
+++ b/config/sync/block.block.tabs.yml
@@ -1,0 +1,21 @@
+uuid: 0ce55948-5250-4fda-9043-efb924836f57
+langcode: en
+status: true
+dependencies:
+  theme:
+    - upd_admin
+id: tabs
+theme: upd_admin
+region: pre_content
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary tabs'
+  provider: core
+  label_display: '0'
+  primary: false
+  secondary: true
+visibility: {  }
+

--- a/config/sync/block.block.upd_admin_local_actions.yml
+++ b/config/sync/block.block.upd_admin_local_actions.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: PffmQ-ABSz5tFjWmVsR7NesunDnEivvopnJnBjl8KNE
 id: upd_admin_local_actions
 theme: upd_admin
-region: header
-weight: -3
+region: content
+weight: -2
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/sync/block.block.upd_admin_local_tasks.yml
+++ b/config/sync/block.block.upd_admin_local_tasks.yml
@@ -8,15 +8,15 @@ _core:
   default_config_hash: c-06bbElRY5sKmglk74ppgTW93Et4-EJFyNiUZMb8JY
 id: upd_admin_local_tasks
 theme: upd_admin
-region: content
-weight: -3
+region: header
+weight: -2
 provider: null
 plugin: local_tasks_block
 settings:
   id: local_tasks_block
-  label: Tabs
+  label: 'Primary tabs'
   provider: core
   label_display: '0'
   primary: true
-  secondary: true
+  secondary: false
 visibility: {  }

--- a/config/sync/block.block.upd_admin_messages.yml
+++ b/config/sync/block.block.upd_admin_messages.yml
@@ -10,8 +10,8 @@ _core:
   default_config_hash: 5MNdk3fpMKx_xxBTcz2T11DL4XEU1H5SgHl8BsYdFsA
 id: upd_admin_messages
 theme: upd_admin
-region: content
-weight: -4
+region: highlighted
+weight: -2
 provider: null
 plugin: system_messages_block
 settings:


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/49742

_(cherry-picked from #346, reviewed and approved by Dan)_
Added basic configuration of the block layout to the `upd_admin` theme.

Configured primary and secondary tabs, status message and breadcrumb.