### PR TITLE
50239 changes to homepage hero text mr prod

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.landing_page.field_footer_area
     - field.field.node.landing_page.field_hero_intro
     - field.field.node.landing_page.field_metatags
+    - field.field.node.landing_page.field_standfirst
     - field.field.node.landing_page.field_testimonial
     - node.type.landing_page
   module:
@@ -20,6 +21,7 @@ dependencies:
     - metatag
     - paragraphs
     - path
+    - text
 third_party_settings:
   field_group:
     group_content_landing:
@@ -99,6 +101,7 @@ third_party_settings:
     group_header_content:
       children:
         - title
+        - field_standfirst
         - field_hero_intro
       parent_name: group_content_landing
       weight: 20
@@ -136,7 +139,7 @@ content:
     region: content
   field_case_studies:
     type: entity_browser_entity_reference
-    weight: 11
+    weight: 12
     region: content
     settings:
       entity_browser: article_browser_case_study
@@ -181,7 +184,7 @@ content:
     type: entity_browser_entity_reference
     region: content
   field_footer_area:
-    weight: 27
+    weight: 28
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -200,7 +203,7 @@ content:
     type: paragraphs
     region: content
   field_hero_intro:
-    weight: 2
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -213,9 +216,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_standfirst:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
   field_testimonial:
     type: entity_reference_paragraphs
-    weight: 4
+    weight: 12
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -283,4 +294,9 @@ content:
       match_limit: 10
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -10,11 +10,13 @@ dependencies:
     - field.field.node.landing_page.field_footer_area
     - field.field.node.landing_page.field_hero_intro
     - field.field.node.landing_page.field_metatags
+    - field.field.node.landing_page.field_standfirst
     - field.field.node.landing_page.field_testimonial
     - node.type.landing_page
   module:
     - entity_reference_revisions
     - metatag
+    - text
     - user
 id: node.landing_page.default
 targetEntityType: node
@@ -80,6 +82,13 @@ content:
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
+  field_standfirst:
+    weight: 10
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_testimonial:
     type: entity_reference_revisions_entity_view
     weight: 3
@@ -96,3 +105,4 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.landing_page.search_result.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.search_result.yml
@@ -10,6 +10,8 @@ dependencies:
     - field.field.node.landing_page.field_featured_articles
     - field.field.node.landing_page.field_footer_area
     - field.field.node.landing_page.field_hero_intro
+    - field.field.node.landing_page.field_metatags
+    - field.field.node.landing_page.field_standfirst
     - field.field.node.landing_page.field_testimonial
     - node.type.landing_page
   module:
@@ -71,4 +73,7 @@ content:
 hidden:
   field_content_area: true
   field_footer_area: true
+  field_metatags: true
+  field_standfirst: true
   langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.teaser.yml
@@ -10,6 +10,8 @@ dependencies:
     - field.field.node.landing_page.field_featured_articles
     - field.field.node.landing_page.field_footer_area
     - field.field.node.landing_page.field_hero_intro
+    - field.field.node.landing_page.field_metatags
+    - field.field.node.landing_page.field_standfirst
     - field.field.node.landing_page.field_testimonial
     - node.type.landing_page
   module:
@@ -29,5 +31,8 @@ hidden:
   field_featured_articles: true
   field_footer_area: true
   field_hero_intro: true
+  field_metatags: true
+  field_standfirst: true
   field_testimonial: true
   langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.node.landing_page.field_standfirst.yml
+++ b/config/sync/field.field.node.landing_page.field_standfirst.yml
@@ -1,0 +1,21 @@
+uuid: 379ed862-ae0f-4fcf-bcfc-797da87c61f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_standfirst
+    - node.type.landing_page
+  module:
+    - text
+id: node.landing_page.field_standfirst
+field_name: field_standfirst
+entity_type: node
+bundle: landing_page
+label: 'Sub-title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/www/themes/upd/assets/css/custom.css
+++ b/www/themes/upd/assets/css/custom.css
@@ -23,7 +23,8 @@
 /* #50240: Change homepage header text.*/
 .with-sub-title {
   padding: 4.3rem 0;
-  font-size: 3rem;
+  font-size: 2.75rem;
+  max-width: 31rem;
 }
 
 .hero__sub-title {

--- a/www/themes/upd/assets/css/custom.css
+++ b/www/themes/upd/assets/css/custom.css
@@ -20,28 +20,39 @@
   padding-top: 4rem;
 }
 
-/* r50240: Change homepage header text.*/
+/* #50240: Change homepage header text.*/
 .with-sub-title {
-  padding: 2rem 0;
+  padding: 4rem 0;
+  font-size: 3.5rem;
 }
 
 .hero__sub-title {
   /* Limit the max height and hide field's content if it goes over. */
-  max-height:250px;
+  max-height: 250px;
   overflow: hidden;
+  /* Sub-title field hidden by default on all displays/devices */
+  display: none;
 }
 
 .hero__sub-title p {
   color: #FFFFFF;
-  font-size: 2rem;
-  line-height: 2.7rem;
+  font-size: 1.75rem;
+  line-height: 2.25rem;
 }
+
+/* Display sub-title field for larger displays (monitors). */
+@media screen and (min-width: 1130px) {
+  .hero__sub-title {
+    display: block;
+  }
+}
+
 /* #50240: Changes to buttons on the homepage. Overrides main.css. */
 .key-info-tile__icon {
   margin-bottom: 20px;
 }
 
-.key-info-tile .cta{
+.key-info-tile .cta {
   font-size: 1.25rem;
 }
 

--- a/www/themes/upd/assets/css/custom.css
+++ b/www/themes/upd/assets/css/custom.css
@@ -22,7 +22,7 @@
 
 /* #50240: Change homepage header text.*/
 .with-sub-title {
-  padding: 4.3rem 0;
+  padding: 7rem 0 5rem;
   font-size: 2.75rem;
   max-width: 31rem;
 }
@@ -39,6 +39,7 @@
   color: #FFFFFF;
   font-size: 1.5rem;
   line-height: 2rem;
+  padding-bottom: 1.35rem;
 }
 
 /* Display sub-title field for larger displays (monitors). */

--- a/www/themes/upd/assets/css/custom.css
+++ b/www/themes/upd/assets/css/custom.css
@@ -22,8 +22,8 @@
 
 /* #50240: Change homepage header text.*/
 .with-sub-title {
-  padding: 4rem 0;
-  font-size: 3.5rem;
+  padding: 4.3rem 0;
+  font-size: 3rem;
 }
 
 .hero__sub-title {
@@ -36,8 +36,8 @@
 
 .hero__sub-title p {
   color: #FFFFFF;
-  font-size: 1.75rem;
-  line-height: 2.25rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
 }
 
 /* Display sub-title field for larger displays (monitors). */

--- a/www/themes/upd/templates/node/node--landing-page.html.twig
+++ b/www/themes/upd/templates/node/node--landing-page.html.twig
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="wrapper wrapper--gutter">
-{% if content.field_standfirst|render|trim %}
+    {% if content.field_standfirst|render|trim %}
       <h1 class="hero__title with-sub-title">{{ label }}</h1>
       <div class="hero__sub-title">{{ content.field_standfirst }}</div>
     {% else %}

--- a/www/themes/upd/templates/node/node--landing-page.html.twig
+++ b/www/themes/upd/templates/node/node--landing-page.html.twig
@@ -13,7 +13,12 @@
       </div>
     </div>
     <div class="wrapper wrapper--gutter">
+{% if content.field_standfirst|render|trim %}
+      <h1 class="hero__title with-sub-title">{{ label }}</h1>
+      <div class="hero__sub-title">{{ content.field_standfirst }}</div>
+    {% else %}
       <h1 class="hero__title">{{ label }}</h1>
+    {% endif %}
       {{ content.field_3_items_grid }}
       <p class="hero__intro">{{ content.field_hero_intro }}</p>
     </div>


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/50239

*This merge request is the result of the aggregation of the following merge requests against `master`:*
- #349
- #355
- #356
- #358
- #359

**Changed hero text at the top of the page above the picture.**

- Added existing field `field_standfirst` as `Sub-title` field to be displayed with the hero image at the top of the `landing_page`.
- Reduced font-sizes for _Title_ and _Sub-title_ (decreased a little), increased spacing around _Title_ (to give more breathing room).
- Responsive support: _Sub-title_ hidden by default on all devices, only displayed for displays over 1130px.
- Reduced the font-size for the Title field and limited the max-width to wrap the text on 3 lines.
- Increased the padding around the Title to push the buttons down below client's floating line.
