### PR TITLE
#50240: Fixed missing 'field_item_info_link' field URL display on hom…

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.grid_items.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.grid_items.default.yml
@@ -8,19 +8,25 @@ dependencies:
     - field.field.paragraph.grid_items.field_item_info_text
     - field.field.paragraph.grid_items.field_svg_reference
     - paragraphs.paragraphs_type.grid_items
+  module:
+    - link
 id: paragraph.grid_items.default
 targetEntityType: paragraph
 bundle: grid_items
 mode: default
 content:
-  field_item_info_button:
+  field_item_info_link:
+    type: link
     weight: 2
+    region: content
     label: above
     settings:
-      link_to_entity: false
+      trim_length: 80
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
-    type: string
-    region: content
   field_item_info_text:
     weight: 0
     label: above
@@ -38,5 +44,5 @@ content:
     type: string
     region: content
 hidden:
-  field_item_info_link: true
+  field_item_info_button: true
   search_api_excerpt: true

--- a/www/themes/upd/templates/paragraphs/paragraph--grid-items.html.twig
+++ b/www/themes/upd/templates/paragraphs/paragraph--grid-items.html.twig
@@ -38,7 +38,7 @@
  * @ingroup themeable
  */
 #}
-<a class="key-info-tile" href="{{ content.field_item_info_link[0]['#plain_text'] }}">
+<a class="key-info-tile" href="{{ content.field_item_info_link.0 }}">
     <div class="key-info-tile__icon">
         <svg class="svg-icon svg-icon--inline" xmlns="http://www.w3.org/2000/svg" role="presentation">
             <use xlink:href="{% spaceless %}{{ content.field_svg_reference }}{% endspaceless %}" />


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/50240#note-17

**Fixed missing `field_item_info_link` field URL display on homepage buttons.**