### PR TITLE
#47063: Replaced 'span' with 'label' in newsletter signup form block …

### DIFF
--- a/www/themes/upd/templates/block/block--mailchimp-signup-subscribe-block.html.twig
+++ b/www/themes/upd/templates/block/block--mailchimp-signup-subscribe-block.html.twig
@@ -1,7 +1,6 @@
 {% block content %}
     <li class="site-footer__section   u-width-1-of-2-from-medium  u-width-1-of-3-from-large">
-      <span class="site-footer__text  site-footer__text--title">Subscribe to
-        the newsletter</span>
+      <label class="site-footer__text  site-footer__text--title">Subscribe to the newsletter</label>
         <!-- Begin MailChimp Signup Form -->
         <div id="mc_embed_signup">
             {{ content }}


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/47063

Replaced `span` with `label` in newsletter signup form block to fix accessibility standard.