### PR TITLE
#47065: Enabled 'description' field for 'field_download_files' file f…

### DIFF
--- a/config/sync/field.field.paragraph.file_download.field_download_files.yml
+++ b/config/sync/field.field.paragraph.file_download.field_download_files.yml
@@ -21,7 +21,7 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'txt pdf ppt pptx doc docx'
   max_filesize: ''
-  description_field: false
+  description_field: true
   handler: 'default:file'
   handler_settings: {  }
 field_type: file


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/47065

Enabled `description` field for `field_download_files` *File* field, to allow the display of `alt`/`title` attributes on `pdfpreview` image.