### PR TITLE
#60761: Updated Drupal core from '9.3.8' to '9.3.9', along with relat…

### DIFF
--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -40,13 +40,13 @@ packages:
     drupal/console-core: 1.9.7
     drupal/console-en: v1.9.7
     drupal/console-extend-plugin: 0.9.5
-    drupal/core: 9.3.8
-    drupal/core-composer-scaffold: 9.3.8
+    drupal/core: 9.3.9
+    drupal/core-composer-scaffold: 9.3.9
     drupal/crop: 2.2.0
     drupal/ctools: 3.7.0
     drupal/devel: 4.1.5
     drupal/draggableviews: 2.0.1
-    drupal/dropzonejs: 2.5.0
+    drupal/dropzonejs: 2.6.0
     drupal/entity_browser: 2.6.0
     drupal/entity_browser_entity_form: 2.6.0
     drupal/entity_reference_display: 1.4.0
@@ -93,7 +93,7 @@ packages:
     grasmash/yaml-expander: 1.4.0
     guzzlehttp/guzzle: 6.5.5
     guzzlehttp/promises: 1.5.1
-    guzzlehttp/psr7: 1.8.3
+    guzzlehttp/psr7: 1.8.5
     joachim-n/composer-manifest: 1.1.4
     laminas/laminas-diactoros: 2.8.0
     laminas/laminas-escaper: 2.9.0

--- a/composer.lock
+++ b/composer.lock
@@ -2593,16 +2593,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.3.8",
+            "version": "9.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "e8e3b7e5b3353f7ebf24de9d39087df75bd66afe"
+                "reference": "86b0c4496e20ae7f945e9a7f0404fafe191ab774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/e8e3b7e5b3353f7ebf24de9d39087df75bd66afe",
-                "reference": "e8e3b7e5b3353f7ebf24de9d39087df75bd66afe",
+                "url": "https://api.github.com/repos/drupal/core/zipball/86b0c4496e20ae7f945e9a7f0404fafe191ab774",
+                "reference": "86b0c4496e20ae7f945e9a7f0404fafe191ab774",
                 "shasum": ""
             },
             "require": {
@@ -2843,11 +2843,11 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2022-03-16T15:34:53+00:00"
+            "time": "2022-03-21T21:21:58+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.3.8",
+            "version": "9.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -3189,17 +3189,17 @@
         },
         {
             "name": "drupal/dropzonejs",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/dropzonejs.git",
-                "reference": "8.x-2.5"
+                "reference": "8.x-2.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/dropzonejs-8.x-2.5.zip",
-                "reference": "8.x-2.5",
-                "shasum": "9918bd8c3c62599ec701be3bbac986741e735859"
+                "url": "https://ftp.drupal.org/files/projects/dropzonejs-8.x-2.6.zip",
+                "reference": "8.x-2.6",
+                "shasum": "3a14b26ade989e00bbbc9f6bbfa364fb5acb9367"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -3213,8 +3213,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.5",
-                    "datestamp": "1614606376",
+                    "version": "8.x-2.6",
+                    "datestamp": "1647857808",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6357,16 +6357,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.3",
+            "version": "1.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/337e3ad8e5716c15f9657bd214d16cc5e69df268",
+                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268",
                 "shasum": ""
             },
             "require": {
@@ -6391,12 +6391,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6459,7 +6459,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-05T13:56:00+00:00"
+            "time": "2022-03-20T21:51:18+00:00"
         },
         {
             "name": "joachim-n/composer-manifest",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2668,17 +2668,17 @@
     },
     {
         "name": "drupal/core",
-        "version": "9.3.8",
-        "version_normalized": "9.3.8.0",
+        "version": "9.3.9",
+        "version_normalized": "9.3.9.0",
         "source": {
             "type": "git",
             "url": "https://github.com/drupal/core.git",
-            "reference": "e8e3b7e5b3353f7ebf24de9d39087df75bd66afe"
+            "reference": "86b0c4496e20ae7f945e9a7f0404fafe191ab774"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/drupal/core/zipball/e8e3b7e5b3353f7ebf24de9d39087df75bd66afe",
-            "reference": "e8e3b7e5b3353f7ebf24de9d39087df75bd66afe",
+            "url": "https://api.github.com/repos/drupal/core/zipball/86b0c4496e20ae7f945e9a7f0404fafe191ab774",
+            "reference": "86b0c4496e20ae7f945e9a7f0404fafe191ab774",
             "shasum": ""
         },
         "require": {
@@ -2845,7 +2845,7 @@
             "drupal/workflows": "self.version",
             "drupal/workspaces": "self.version"
         },
-        "time": "2022-03-16T15:34:53+00:00",
+        "time": "2022-03-21T21:21:58+00:00",
         "type": "drupal-core",
         "extra": {
             "drupal-scaffold": {
@@ -2924,8 +2924,8 @@
     },
     {
         "name": "drupal/core-composer-scaffold",
-        "version": "9.3.8",
-        "version_normalized": "9.3.8.0",
+        "version": "9.3.9",
+        "version_normalized": "9.3.9.0",
         "source": {
             "type": "git",
             "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -3276,18 +3276,18 @@
     },
     {
         "name": "drupal/dropzonejs",
-        "version": "2.5.0",
-        "version_normalized": "2.5.0.0",
+        "version": "2.6.0",
+        "version_normalized": "2.6.0.0",
         "source": {
             "type": "git",
             "url": "https://git.drupalcode.org/project/dropzonejs.git",
-            "reference": "8.x-2.5"
+            "reference": "8.x-2.6"
         },
         "dist": {
             "type": "zip",
-            "url": "https://ftp.drupal.org/files/projects/dropzonejs-8.x-2.5.zip",
-            "reference": "8.x-2.5",
-            "shasum": "9918bd8c3c62599ec701be3bbac986741e735859"
+            "url": "https://ftp.drupal.org/files/projects/dropzonejs-8.x-2.6.zip",
+            "reference": "8.x-2.6",
+            "shasum": "3a14b26ade989e00bbbc9f6bbfa364fb5acb9367"
         },
         "require": {
             "drupal/core": "^8.8 || ^9"
@@ -3301,8 +3301,8 @@
         "type": "drupal-module",
         "extra": {
             "drupal": {
-                "version": "8.x-2.5",
-                "datestamp": "1614606376",
+                "version": "8.x-2.6",
+                "datestamp": "1647857808",
                 "security-coverage": {
                     "status": "covered",
                     "message": "Covered by Drupal's security advisory policy"
@@ -6576,17 +6576,17 @@
     },
     {
         "name": "guzzlehttp/psr7",
-        "version": "1.8.3",
-        "version_normalized": "1.8.3.0",
+        "version": "1.8.5",
+        "version_normalized": "1.8.5.0",
         "source": {
             "type": "git",
             "url": "https://github.com/guzzle/psr7.git",
-            "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+            "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-            "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+            "url": "https://api.github.com/repos/guzzle/psr7/zipball/337e3ad8e5716c15f9657bd214d16cc5e69df268",
+            "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268",
             "shasum": ""
         },
         "require": {
@@ -6604,7 +6604,7 @@
         "suggest": {
             "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
         },
-        "time": "2021-10-05T13:56:00+00:00",
+        "time": "2022-03-20T21:51:18+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -6613,12 +6613,12 @@
         },
         "installation-source": "dist",
         "autoload": {
-            "psr-4": {
-                "GuzzleHttp\\Psr7\\": "src/"
-            },
             "files": [
                 "src/functions_include.php"
-            ]
+            ],
+            "psr-4": {
+                "GuzzleHttp\\Psr7\\": "src/"
+            }
         },
         "notification-url": "https://packagist.org/downloads/",
         "license": [

--- a/vendor/guzzlehttp/psr7/CHANGELOG.md
+++ b/vendor/guzzlehttp/psr7/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.8.5 - 2022-03-20
+
+### Fixed
+
+- Correct header value validation
+
+## 1.8.4 - 2022-03-20
+
+### Fixed
+
+- Validate header values properly
+
 ## 1.8.3 - 2021-10-05
 
 ### Fixed

--- a/vendor/guzzlehttp/psr7/composer.json
+++ b/vendor/guzzlehttp/psr7/composer.json
@@ -68,6 +68,9 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        }
     }
 }

--- a/vendor/guzzlehttp/psr7/src/MessageTrait.php
+++ b/vendor/guzzlehttp/psr7/src/MessageTrait.php
@@ -157,17 +157,22 @@ trait MessageTrait
         }
     }
 
+    /**
+     * @param mixed $value
+     *
+     * @return string[]
+     */
     private function normalizeHeaderValue($value)
     {
         if (!is_array($value)) {
-            return $this->trimHeaderValues([$value]);
+            return $this->trimAndValidateHeaderValues([$value]);
         }
 
         if (count($value) === 0) {
             throw new \InvalidArgumentException('Header value can not be an empty array.');
         }
 
-        return $this->trimHeaderValues($value);
+        return $this->trimAndValidateHeaderValues($value);
     }
 
     /**
@@ -178,13 +183,13 @@ trait MessageTrait
      * header-field = field-name ":" OWS field-value OWS
      * OWS          = *( SP / HTAB )
      *
-     * @param string[] $values Header values
+     * @param mixed[] $values Header values
      *
      * @return string[] Trimmed header values
      *
      * @see https://tools.ietf.org/html/rfc7230#section-3.2.4
      */
-    private function trimHeaderValues(array $values)
+    private function trimAndValidateHeaderValues(array $values)
     {
         return array_map(function ($value) {
             if (!is_scalar($value) && null !== $value) {
@@ -194,10 +199,20 @@ trait MessageTrait
                 ));
             }
 
-            return trim((string) $value, " \t");
+            $trimmed = trim((string) $value, " \t");
+            $this->assertValue($trimmed);
+
+            return $trimmed;
         }, array_values($values));
     }
 
+    /**
+     * @see https://tools.ietf.org/html/rfc7230#section-3.2
+     *
+     * @param mixed $header
+     *
+     * @return void
+     */
     private function assertHeader($header)
     {
         if (!is_string($header)) {
@@ -209,6 +224,47 @@ trait MessageTrait
 
         if ($header === '') {
             throw new \InvalidArgumentException('Header name can not be empty.');
+        }
+
+        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/', $header)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '"%s" is not valid header name',
+                    $header
+                )
+            );
+        }
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return void
+     *
+     * @see https://tools.ietf.org/html/rfc7230#section-3.2
+     *
+     * field-value    = *( field-content / obs-fold )
+     * field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+     * field-vchar    = VCHAR / obs-text
+     * VCHAR          = %x21-7E
+     * obs-text       = %x80-FF
+     * obs-fold       = CRLF 1*( SP / HTAB )
+     */
+    private function assertValue($value)
+    {
+        // The regular expression intentionally does not support the obs-fold production, because as
+        // per RFC 7230#3.2.4:
+        //
+        // A sender MUST NOT generate a message that includes
+        // line folding (i.e., that has any field-value that contains a match to
+        // the obs-fold rule) unless the message is intended for packaging
+        // within the message/http media type.
+        //
+        // Clients must not send a request with line folding and a server sending folded headers is
+        // likely very rare. Line folding is a fairly obscure feature of HTTP/1.1 and thus not accepting
+        // folding is not likely to break any legitimate use case.
+        if (! preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/', $value)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid header value', $value));
         }
     }
 }

--- a/www/core/lib/Drupal.php
+++ b/www/core/lib/Drupal.php
@@ -75,7 +75,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '9.3.8';
+  const VERSION = '9.3.9';
 
   /**
    * Core API compatibility.

--- a/www/modules/contrib/dropzonejs/README.md
+++ b/www/modules/contrib/dropzonejs/README.md
@@ -36,10 +36,15 @@ installed to the `libraries` folder automatically.
 
 #### The composer way 2
 
-Copy the following into the root `composer.json` file's `repository` key
+Add a custom package to the root `composer.json` file. Its `repositories` key
+looks like the following.
 
 ```
     "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
         {
             "type": "package",
             "package": {

--- a/www/modules/contrib/dropzonejs/dropzonejs.info.yml
+++ b/www/modules/contrib/dropzonejs/dropzonejs.info.yml
@@ -6,7 +6,7 @@ package: Media
 dependencies:
   - drupal:file
 
-# Information added by Drupal.org packaging script on 2021-03-01
-version: '8.x-2.5'
+# Information added by Drupal.org packaging script on 2022-03-21
+version: '8.x-2.6'
 project: 'dropzonejs'
-datestamp: 1614606378
+datestamp: 1647857810

--- a/www/modules/contrib/dropzonejs/dropzonejs.libraries.yml
+++ b/www/modules/contrib/dropzonejs/dropzonejs.libraries.yml
@@ -26,3 +26,10 @@ integration:
     - core/drupalSettings
     - core/underscore
     - dropzonejs/dropzonejs
+
+media_library:
+  version: VERSION
+  js:
+    js/dropzone.media_library.js: {}
+  dependencies:
+    - dropzonejs/integration

--- a/www/modules/contrib/dropzonejs/dropzonejs.module
+++ b/www/modules/contrib/dropzonejs/dropzonejs.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\dropzonejs\Form\DropzoneJsUploadForm;
 
 /**
  * Implements hook_help().
@@ -111,5 +112,26 @@ function dropzonejs_library_info_alter(&$libraries, $extension) {
     if ($exif_path = libraries_get_path('exif-js')) {
       $libraries['exif-js']['js'] = ['/' . $exif_path . '/exif.js' => []];
     }
+  }
+}
+
+/**
+ * Implements hook_media_source_info_alter().
+ */
+function dropzonejs_media_source_info_alter(array &$sources) {
+  if (isset($sources['image'])) {
+    $sources['image']['forms']['media_library_add'] = DropzoneJsUploadForm::class;
+  }
+
+  if (isset($sources['video_file'])) {
+    $sources['video_file']['forms']['media_library_add'] = DropzoneJsUploadForm::class;
+  }
+
+  if (isset($sources['audio_file'])) {
+    $sources['audio_file']['forms']['media_library_add'] = DropzoneJsUploadForm::class;
+  }
+
+  if (isset($sources['file'])) {
+    $sources['file']['forms']['media_library_add'] = DropzoneJsUploadForm::class;
   }
 }

--- a/www/modules/contrib/dropzonejs/js/dropzone.integration.js
+++ b/www/modules/contrib/dropzonejs/js/dropzone.integration.js
@@ -15,7 +15,7 @@
     attach: function (context) {
       Dropzone.autoDiscover = false;
 
-      $('.dropzone-enable').each(function() {
+      $('.dropzone-enable', context).each(function () {
         var selector = $(this);
         selector.addClass('dropzone');
 

--- a/www/modules/contrib/dropzonejs/js/dropzone.media_library.js
+++ b/www/modules/contrib/dropzonejs/js/dropzone.media_library.js
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * dropzonejs_eb_widget.common.js
+ *
+ * Bundles various dropzone eb widget behaviours.
+ */
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.dropzonejsPostIntegrationMediaLibrary = {
+    attach: function (context) {
+      if (typeof drupalSettings.dropzonejs.instances !== 'undefined') {
+        _.each(drupalSettings.dropzonejs.instances, function (item) {
+          if (typeof item.instance !== 'undefined') {
+
+            var $form = $(item.instance.element).parents('form');
+
+            item.instance.on('queuecomplete', function () {
+              var dzInstance = item.instance;
+              var filesInQueue = dzInstance.getQueuedFiles();
+              var acceptedFiles;
+              var i;
+
+              if (filesInQueue.length === 0) {
+                acceptedFiles = dzInstance.getAcceptedFiles();
+
+                // Ensure that there are some files that should be submitted.
+                if (acceptedFiles.length > 0 && dzInstance.getUploadingFiles().length === 0) {
+                  // First submit accepted files and clear them from list of
+                  // dropped files afterwards.
+                  $form.find('[id="auto_select_handler"]')
+                    .trigger('auto_select_media_library_widget');
+
+                  // Remove accepted files -> because they are submitted.
+                  for (i = 0; i < acceptedFiles.length; i++) {
+                    dzInstance.removeFile(acceptedFiles[i]);
+                  }
+                }
+              }
+            });
+          }
+        });
+      }
+    }
+  };
+
+}(jQuery, Drupal, drupalSettings));

--- a/www/modules/contrib/dropzonejs/modules/eb_widget/dropzonejs_eb_widget.info.yml
+++ b/www/modules/contrib/dropzonejs/modules/eb_widget/dropzonejs_eb_widget.info.yml
@@ -9,7 +9,7 @@ dependencies:
   - entity_browser:entity_browser
 
 
-# Information added by Drupal.org packaging script on 2021-03-01
-version: '8.x-2.5'
+# Information added by Drupal.org packaging script on 2022-03-21
+version: '8.x-2.6'
 project: 'dropzonejs'
-datestamp: 1614606378
+datestamp: 1647857810

--- a/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -131,7 +131,7 @@ class DropzoneJsEbWidget extends WidgetBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return [
+    return array_merge(parent::defaultConfiguration(), [
       'upload_location' => 'public://[date:custom:Y]-[date:custom:m]',
       'dropzone_description' => $this->t('Drop files here to upload them'),
       'max_filesize' => Environment::getUploadMaxSize() / pow(Bytes::KILOBYTE, 2) . 'M',
@@ -142,7 +142,7 @@ class DropzoneJsEbWidget extends WidgetBase {
       'resize_quality' => 1,
       'resize_method' => 'contain',
       'thumbnail_method' => 'contain',
-    ] + parent::defaultConfiguration();
+    ]);
   }
 
   /**

--- a/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/InlineEntityFormMediaWidget.php
+++ b/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/InlineEntityFormMediaWidget.php
@@ -54,9 +54,9 @@ class InlineEntityFormMediaWidget extends MediaEntityDropzoneJsEbWidget {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return [
+    return array_merge(parent::defaultConfiguration(), [
       'form_mode' => 'default',
-    ] + parent::defaultConfiguration();
+    ]);
   }
 
   /**

--- a/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
+++ b/www/modules/contrib/dropzonejs/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
@@ -55,9 +55,9 @@ class MediaEntityDropzoneJsEbWidget extends DropzoneJsEbWidget {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return [
+    return array_merge(parent::defaultConfiguration(), [
       'media_type' => '',
-    ] + parent::defaultConfiguration();
+    ]);
   }
 
   /**

--- a/www/modules/contrib/dropzonejs/src/Element/DropzoneJs.php
+++ b/www/modules/contrib/dropzonejs/src/Element/DropzoneJs.php
@@ -76,9 +76,6 @@ class DropzoneJs extends FormElement {
       '#theme' => 'dropzonejs',
       '#theme_wrappers' => ['form_element'],
       '#tree' => TRUE,
-      '#attached' => [
-        'library' => ['dropzonejs/integration'],
-      ],
     ];
   }
 
@@ -86,6 +83,8 @@ class DropzoneJs extends FormElement {
    * Processes a dropzone upload element.
    */
   public static function processDropzoneJs(&$element, FormStateInterface $form_state, &$complete_form) {
+    // Generate url and collect metadata for CSRF token to be up to date.
+    $generated_url = Url::fromRoute('dropzonejs.upload')->toString(TRUE);
     $element['uploaded_files'] = [
       '#type' => 'hidden',
       // @todo Handle defaults.
@@ -93,9 +92,10 @@ class DropzoneJs extends FormElement {
       // If we send a url with a token through drupalSettings the placeholder
       // doesn't get replaced, because the actual scripts markup is not there
       // yet. So we pass this information through a data attribute.
-      '#attributes' => ['data-upload-path' => Url::fromRoute('dropzonejs.upload')->toString()],
+      '#attributes' => ['data-upload-path' => $generated_url->getGeneratedUrl()],
     ];
-
+    // Apply cacheable metadata to element.
+    $generated_url->applyTo($element);
     if (empty($element['#max_filesize'])) {
       $element['#max_filesize'] = Environment::getUploadMaxSize();
     }
@@ -129,6 +129,7 @@ class DropzoneJs extends FormElement {
     // Convert the human size input to bytes, convert it to MB and round it.
     $max_size = round(Bytes::toInt($element['#max_filesize']) / pow(Bytes::KILOBYTE, 2), 2);
 
+    $element['#attached']['library'] = ['dropzonejs/integration'];
     $element['#attached']['drupalSettings']['dropzonejs'] = [
       'instances' => [
         // Configuration keys are matched with DropzoneJS configuration

--- a/www/modules/contrib/dropzonejs/src/Form/DropzoneJsUploadForm.php
+++ b/www/modules/contrib/dropzonejs/src/Form/DropzoneJsUploadForm.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Drupal\dropzonejs\Form;
+
+use Drupal\Component\Utility\Bytes;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\dropzonejs\DropzoneJsUploadSaveInterface;
+use Drupal\media_library\Form\FileUploadForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Creates a form to create media entities from uploaded files.
+ */
+class DropzoneJsUploadForm extends FileUploadForm {
+
+  /**
+   * DropzoneJS module upload save service.
+   *
+   * @var \Drupal\dropzonejs\DropzoneJsUploadSaveInterface
+   */
+  protected $dropzoneJsUploadSave;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $form = parent::create($container);
+    $form->setDropzoneJsUploadSave($container->get('dropzonejs.upload_save'));
+    return $form;
+  }
+
+  /**
+   * Set the upload service.
+   *
+   * @param \Drupal\dropzonejs\DropzoneJsUploadSaveInterface $dropzoneJsUploadSave
+   *   The upload service.
+   */
+  protected function setDropzoneJsUploadSave(DropzoneJsUploadSaveInterface $dropzoneJsUploadSave) {
+    $this->dropzoneJsUploadSave = $dropzoneJsUploadSave;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildInputElement(array $form, FormStateInterface $form_state) {
+    $form = parent::buildInputElement($form, $form_state);
+    // Create a file item to get the upload validators.
+    $media_type = $this->getMediaType($form_state);
+    $item = $this->createFileItem($media_type);
+    $settings = $item->getFieldDefinition()->getSettings();
+    $slots = $form['container']['upload']['#cardinality'];
+    $process = (array) $this->elementInfo->getInfoProperty('dropzonejs', '#process', []);
+    $form['container']['upload']['#type'] = 'dropzonejs';
+    $form['container']['upload']['#process'] = array_merge(['::validateUploadElement'], $process);
+    $dropzone_specific_properties = [
+      '#max_files' => $slots < 1 ? 0 : $slots,
+      '#max_filesize' => $settings['max_filesize'],
+      '#extensions' => $settings['file_extensions'],
+      '#dropzone_description' => $this->t('Drop files here to upload them'),
+    ];
+    $form['container']['upload'] += $dropzone_specific_properties;
+
+    $form['auto_select_handler'] = [
+      '#type' => 'hidden',
+      '#name' => 'auto_select_handler',
+      '#id' => 'auto_select_handler',
+      '#attributes' => ['id' => 'auto_select_handler'],
+      '#submit' => ['::uploadButtonSubmit'],
+      '#executes_submit_callback' => TRUE,
+      '#ajax' => [
+        'callback' => '::updateFormCallback',
+        'wrapper' => 'media-library-wrapper',
+        'event' => 'auto_select_media_library_widget',
+        // Add a fixed URL to post the form since AJAX forms are automatically
+        // posted to <current> instead of $form['#action'].
+        // @todo Remove when https://www.drupal.org/project/drupal/issues/2504115
+        // is fixed.
+        // Follow along with changes in \Drupal\media_library\Form\OEmbedForm.
+        'url' => Url::fromRoute('media_library.ui'),
+        'options' => [
+          'query' => $this->getMediaLibraryState($form_state)->all() + [
+              FormBuilderInterface::AJAX_FORM_REQUEST => TRUE,
+            ],
+        ],
+      ],
+    ];
+
+    $form['#attached']['library'][] = 'dropzonejs/widget';
+    $form['#attached']['library'][] = 'dropzonejs/media_library';
+
+    return $form;
+  }
+
+  /**
+   * Validates the upload element.
+   *
+   * @param array $element
+   *   The upload element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The processed upload element.
+   */
+  public function validateUploadElement(array $element, FormStateInterface $form_state) {
+    if ($form_state::hasAnyErrors()) {
+      // When an error occurs during uploading files, remove all files so the
+      // user can re-upload the files.
+      $element['#value'] = [];
+    }
+    $values = $form_state->getValue('upload', []);
+    if (count($values['uploaded_files']) > $element['#cardinality'] && $element['#cardinality'] !== FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
+      $form_state->setError($element, $this->t('A maximum of @count files can be uploaded.', [
+        '@count' => $element['#cardinality'],
+      ]));
+      $form_state->setValue('upload', []);
+      $element['#value'] = [];
+    }
+    return $element;
+  }
+
+  /**
+   * Submit handler for the upload button, inside the managed_file element.
+   *
+   * @param array $form
+   *   The form render array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function uploadButtonSubmit(array $form, FormStateInterface $form_state) {
+    $files = $this->getFiles($form, $form_state);
+    $this->processInputValues($files, $form, $form_state);
+  }
+
+  /**
+   * Gets uploaded files.
+   *
+   * We implement this to allow child classes to operate on different entity
+   * type while still having access to the files in the validate callback here.
+   *
+   * @param array $form
+   *   Form structure.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return \Drupal\file\FileInterface[]
+   *   Array of uploaded files.
+   */
+  protected function getFiles(array $form, FormStateInterface $form_state) {
+    // Create a file item to get the upload validators.
+    $media_type = $this->getMediaType($form_state);
+    $item = $this->createFileItem($media_type);
+
+    $settings = $item->getFieldDefinition()->getSettings();
+
+    $additional_validators = ['file_validate_size' => [Bytes::toInt($settings['max_filesize']), 0]];
+
+    $files = $form_state->get(['dropzonejs', $this->getFormId(), 'files']);
+
+    if (!$files) {
+      $files = [];
+    }
+
+    // We do some casting because $form_state->getValue() might return NULL.
+    foreach ((array) $form_state->getValue(['upload', 'uploaded_files'], []) as $file) {
+      if (file_exists($file['path'])) {
+        $entity = $this->dropzoneJsUploadSave->createFile(
+          $file['path'],
+          // Need to leave destination empty, because Media Library will handle
+          // the moving of the file to proper location.
+          '',
+          $settings['file_extensions'],
+          $this->currentUser(),
+          $additional_validators
+        );
+        if ($entity) {
+          $files[] = $entity;
+        }
+      }
+    }
+
+    if ($form['container']['upload']['#max_files']) {
+      $files = array_slice($files, -$form['container']['upload']['#max_files']);
+    }
+
+    $form_state->set(['dropzonejs', $this->getFormId(), 'files'], $files);
+
+    return $files;
+  }
+
+}

--- a/www/modules/contrib/dropzonejs/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
+++ b/www/modules/contrib/dropzonejs/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
@@ -9,7 +9,7 @@ dependencies:
  - dropzonejs:dropzonejs
  - dropzonejs:dropzonejs_eb_widget
 
-# Information added by Drupal.org packaging script on 2021-03-01
-version: '8.x-2.5'
+# Information added by Drupal.org packaging script on 2022-03-21
+version: '8.x-2.6'
 project: 'dropzonejs'
-datestamp: 1614606378
+datestamp: 1647857810


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/60761

**Application updates:** addressing [Drupal core - Moderately critical - Third-party libraries - SA-CORE-2022-006](https://www.drupal.org/sa-core-2022-006)
* Updated Drupal core from `9.3.8` to `9.3.9`
* Along with related vendor library `guzzlehttp/psr7:1.8.5`
* and module `dropzonejs:2.6.0`.

No db update and no config change.

This commit is the result of the local execution of the following commands:
```
composer update --with-dependencies
drush cr
drush updb
drush cr
drush cex
```