### PR TITLE
#62947: Enable deployment with 'composer' to fix broken 'prod' build,…

### DIFF
--- a/prod.config.ini
+++ b/prod.config.ini
@@ -22,8 +22,8 @@ appip2=172.30.1.30
 
 ; Build configuration
 [Drupal]
-drupal_version=8
+drupal_version=9
 import_config=True
 
 [Composer]
-composer=False
+composer=True


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/62947#note-2

(Follow-up to PR #489 on `prod` )

Enable deployment with `composer` to fix broken `prod` build, due to previous commits removing source files, follow-up to commit [90dce26](https://github.com/wellcometrust/upd/pull/489/commits/90dce2602e3a49f04ae997b2a8a8a2e7f42993a2).