### PR TITLE
64697 fix accessibility issues mr master

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,7 +1,7 @@
 {
     "patches": {
         "drupal/video_embed_field": {
-            "Add 'title' attribute to YouTube, Vimeo, and Playlist embeds https://www.drupal.org/project/video_embed_field/issues/3200253#comment-14944094": "https://www.drupal.org/files/issues/2023-02-28/3200253-17.patch"
+            "Add 'title' attribute to YouTube, Vimeo, and Playlist embeds https://www.drupal.org/project/video_embed_field/issues/3200253#comment-14793136": "https://www.drupal.org/files/issues/2022-11-18/3200253-video_embed_field--attirbute-title--11.patch"
         }
     }
 }


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/64697#note-14

**Accessibility:**
Downgraded patch previously applied to contrib module `video_embed_field` to use patch from [Drupal.org, Issues for module Video Embed Field: Add "title" attribute to YouTube, Vimeo, and Playlist embeds, comment #11](https://www.drupal.org/project/video_embed_field/issues/3200253#comment-14793136) to be compatible with PHP 7.4.